### PR TITLE
Ensuring that the content of the posts will always be displayed

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -1,5 +1,6 @@
 TITLE: "Title"
 ONLY_ADMIN: "You need to be an admin to perform this action"
+LANGUAGE_NOT_AVAILABLE: "English version of this post was not found, showing the Spanish version instead"
 testing: "This is a test page"
 
 # Navbar

--- a/app/Resources/translations/messages.es.yml
+++ b/app/Resources/translations/messages.es.yml
@@ -1,5 +1,6 @@
 TITLE: "Título"
 ONLY_ADMIN: "Necesitas ser administrador para ejecutar esta acción"
+LANGUAGE_NOT_AVAILABLE: "No se encontró la versión en español para este artículo, se muestra en su lugar la versión en inglés"
 testing: "Esta es una página de prueba"
 
 # Navbar

--- a/app/Resources/views/admin/posts-view.html.twig
+++ b/app/Resources/views/admin/posts-view.html.twig
@@ -5,20 +5,42 @@
 {% block body %}
     <div class="container mt-5 page">
         <h2>
-            {% if app.request.locale == 'es' %}
+            {% if app.request.locale == 'en' and post.titleEn %}
+                {{ post.titleEn }}
+            {% elseif app.request.locale == 'en' and post.titleEs %}
                 {{ post.titleEs }}
-            {% else %}
+            {% endif %}
+            {% if app.request.locale == 'es' and post.titleEs %}
+                {{ post.titleEs }}
+            {% elseif app.request.locale == 'es' and post.titleEn %}
                 {{ post.titleEn }}
             {% endif %}
         </h2>
         <div class="content">
-            {% if app.request.locale == 'es' %}
+            {% if app.request.locale == 'en' and not post.titleEn or
+            app.request.locale == 'es' and not post.titleEs %}
+                <div class="alert alert-danger" role="alert">
+                    {{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
+                </div>
+            {% elseif app.request.locale == 'en' and post.titleEn %}
+                {{ post.contentEn|raw|md2html }}
+                <div class="mt-5">
+                    <h3>{{ 'POST_EXCERPT'|trans }}</h3>
+                    {{ post.excerptEn }}
+                </div>
+            {% elseif app.request.locale == 'en' and post.titleEs %}
                 {{ post.contentEs|raw|md2html }}
                 <div class="mt-5">
                     <h3>{{ 'POST_EXCERPT'|trans }}</h3>
                     {{ post.excerptEs }}
                 </div>
-            {% else %}
+            {% elseif app.request.locale == 'es' and post.titleEs %}
+                {{ post.contentEs|raw|md2html }}
+                <div class="mt-5">
+                    <h3>{{ 'POST_EXCERPT'|trans }}</h3>
+                    {{ post.excerptEs }}
+                </div>
+            {% elseif app.request.locale == 'es' and post.titleEn %}
                 {{ post.contentEn|raw|md2html }}
                 <div class="mt-5">
                     <h3>{{ 'POST_EXCERPT'|trans }}</h3>

--- a/app/Resources/views/public/post.html.twig
+++ b/app/Resources/views/public/post.html.twig
@@ -5,16 +5,30 @@
 {% block body %}
     <div class="container mt-5 page">
         <h2>
-            {% if app.request.locale == 'es' %}
+            {% if app.request.locale == 'en' and post.titleEn %}
+                {{ post.titleEn }}
+            {% elseif app.request.locale == 'en' and post.titleEs %}
                 {{ post.titleEs }}
-            {% else %}
+            {% elseif app.request.locale == 'es' and post.titleEs %}
+                {{ post.titleEs }}
+            {% elseif app.request.locale == 'es' and post.titleEn %}
                 {{ post.titleEn }}
             {% endif %}
         </h2>
         <div class="content">
-            {% if app.request.locale == 'es' %}
+            {% if app.request.locale == 'en' and not post.titleEn or
+            app.request.locale == 'es' and not post.titleEs %}
+                <div class="alert alert-danger" role="alert">
+                    {{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
+                </div>
+            {% endif %}
+            {% if app.request.locale == 'en' and post.titleEn %}
+                {{ post.contentEn|raw|md2html }}
+            {% elseif app.request.locale == 'en' and post.titleEs %}
                 {{ post.contentEs|raw|md2html }}
-            {% else %}
+            {% elseif app.request.locale == 'es' and post.titleEs %}
+                {{ post.contentEs|raw|md2html }}
+            {% elseif app.request.locale == 'es' and post.titleEn %}
                 {{ post.contentEn|raw|md2html }}
             {% endif %}
         </div>


### PR DESCRIPTION
Although the point is to always write each post in Spanish and English, the post may not be available in the chosen language (English maybe 😜 ). Now, when this happens, an alert will be displayed to indicate that although the content is not available in the chosen language, the content will be displayed in the other available language.