### PR TITLE
Changing the behavior of admin-panel's post preview

### DIFF
--- a/app/Resources/views/admin/pages.html.twig
+++ b/app/Resources/views/admin/pages.html.twig
@@ -62,11 +62,19 @@
                             {{ page.commentCount }}
                         </td>
                         <td class="text-center">
-                            <a href="{{ path('admin_pages_view',
-                            { 'id': page.id }) }}"
-                               class="btn btn-sm btn-info text-center">
-                                <i class="fa fa-eye" aria-hidden="true"></i>
-                            </a>
+                            {% if page.status == 'draft' %}
+                                <a href="{{ path('admin_pages_view',
+                                { 'id': page.id }) }}"
+                                   class="btn btn-sm btn-info text-center">
+                                    <i class="fa fa-eye" aria-hidden="true"></i>
+                                </a>
+                            {% else %}
+                                <a href="{{ path('post',
+                                { 'slug': page.slug }) }}"
+                                   class="btn btn-sm btn-info text-center">
+                                    <i class="fa fa-eye" aria-hidden="true"></i>
+                                </a>
+                            {% endif %}
                             {% if is_granted('ROLE_SUPER_ADMIN') or
                             page.author == app.user.id %}
                                 <a href="{{ path('admin_pages_edit',

--- a/app/Resources/views/admin/posts.html.twig
+++ b/app/Resources/views/admin/posts.html.twig
@@ -62,11 +62,19 @@
                             {{ post.commentCount }}
                         </td>
                         <td class="text-center">
-                            <a href="{{ path('admin_posts_view',
-                            { 'id': post.id }) }}"
-                               class="btn btn-sm btn-info text-center">
-                                <i class="fa fa-eye" aria-hidden="true"></i>
-                            </a>
+                            {% if post.status == 'draft' %}
+                                <a href="{{ path('admin_posts_view',
+                                { 'id': post.id }) }}"
+                                   class="btn btn-sm btn-info text-center">
+                                    <i class="fa fa-eye" aria-hidden="true"></i>
+                                </a>
+                            {% else %}
+                                <a href="{{ path('post',
+                                { 'slug': post.slug }) }}"
+                                   class="btn btn-sm btn-info text-center">
+                                    <i class="fa fa-eye" aria-hidden="true"></i>
+                                </a>
+                            {% endif %}
                             {% if is_granted('ROLE_SUPER_ADMIN') or
                             post.author == app.user.id %}
                                 <a href="{{ path('admin_posts_edit',


### PR DESCRIPTION
Added the enhancement commented in the issue #7. Now, the preview button for posts and pages in the admin panel, redirects to the page or post when it has already been published, rather than to the preview.