### PR TITLE
Fixing a bug in admin panel dates

### DIFF
--- a/app/Resources/views/admin/pages.html.twig
+++ b/app/Resources/views/admin/pages.html.twig
@@ -48,7 +48,7 @@
                         {% endif %}
                         {% if page.status == 'publish' %}
                             <td class="d-none d-sm-table-cell text-center">
-                                {{ page.modDate|date("d/m/Y") }}
+                                {{ page.date|date("d/m/Y") }}
                             </td>
                         {% else %}
                             <td class="d-none d-sm-table-cell text-center">

--- a/app/Resources/views/admin/posts.html.twig
+++ b/app/Resources/views/admin/posts.html.twig
@@ -48,7 +48,7 @@
                         {% endif %}
                         {% if post.status == 'publish' %}
                             <td class="d-none d-sm-table-cell text-center">
-                                {{ post.modDate|date("d/m/Y") }}
+                                {{ post.date|date("d/m/Y") }}
                             </td>
                         {% else %}
                             <td class="d-none d-sm-table-cell text-center">


### PR DESCRIPTION
As mentioned in #19: dates that were printed in the lists of posts and pages of the admin panel were not the publication date, as they should have been, but the last modification date. Fixed it.