### PR TITLE
Feature: sitemap generator

### DIFF
--- a/app/Resources/views/public/sitemap.xml.twig
+++ b/app/Resources/views/public/sitemap.xml.twig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+{% if index is defined %}
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    {% for url in urls %}
+        <sitemap>
+            {% if url.loc|replace({hostname:''}) == url.loc %}
+                <loc>{{ hostname }}{{ url.loc }}</loc>
+            {% else %}
+                <loc>{{ url.loc }}</loc>
+            {% endif %}
+            {% if url.modDate is defined %}
+                <lastmod>{{ url.modDate|date('r', timezone='GMT') }}</lastmod>
+            {% endif %}
+        </sitemap>
+    {% endfor %}
+    {% else %}
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            {% for url in urls %}
+                <url>
+                    {% if url.loc|replace({hostname:''}) == url.loc %}
+                        <loc>{{ hostname }}{{ url.loc }}</loc>
+                    {% else %}
+                        <loc>{{ url.loc }}</loc>
+                    {% endif %}
+                    {% if url.modDate is defined %}
+                        <lastmod>{{ url.modDate|date('r', timezone='GMT') }}</lastmod>
+                    {% endif %}
+                    {% if url.changefreq is defined %}
+                        <changefreq>{{ url.changefreq }}</changefreq>
+                    {% endif %}
+                    {% if url.priority is defined %}
+                        <priority>{{ url.priority }}</priority>
+                    {% endif %}
+                </url>
+            {% endfor %}
+        </urlset>
+    {% endif %}

--- a/src/AppBundle/Controller/SitemapController.php
+++ b/src/AppBundle/Controller/SitemapController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class SitemapController extends Controller
+{
+    /**
+     * @Route("/sitemap.xml", name="sitemap")
+     */
+    public function sitemapAction(Request $request)
+    {
+        $em = $this->getDoctrine()->getManager();
+        $urls = array();
+        $hostname = $request->getSchemeAndHttpHost();
+        $urls[] = array(
+                'loc' => '/sitemap-en.xml',
+                'modDate' => date('r'),
+                'changefreq' => 'daily',
+                'priority' => '0.5'
+        );
+        $urls[] = array(
+                'loc' => '/sitemap-es.xml',
+                'modDate' => date('r'),
+                'changefreq' => 'daily',
+                'priority' => '0.5'
+        );
+        return $this->render('public/sitemap.xml.twig', array(
+                'urls' => $urls,
+                'hostname' => $hostname,
+                'index' => true
+        ));
+    }
+
+    /**
+     * @Route("/sitemap-en.xml", name="sitemap_en")
+     */
+    public function sitemapEnAction(Request $request)
+    {
+        $em = $this->getDoctrine()->getManager();
+        $urls = array();
+        $hostname = $request->getSchemeAndHttpHost();
+        $posts = $em->getRepository('AppBundle:Post')
+                ->findBy(array(
+                        'status' => 'publish'), array(
+                        'modDate' => 'DESC'
+                ));
+        foreach ($posts as $post) {
+            $urls[] = array(
+                    'loc' => $this->get('router')->generate('post', array(
+                            'slug' => $post->getSlug(),
+                            '_locale' => 'en'
+                    )),
+                    'modDate' => $post->getModDate(),
+                    'changefreq' => 'daily',
+                    'priority' => '0.5'
+            );
+        }
+        $urls[] = array(
+                'loc' => $this->get('router')->generate('home'),
+                'changefreq' => 'weekly',
+                'priority' => '1.0'
+        );
+        return $this->render('public/sitemap.xml.twig', array(
+                'urls' => $urls,
+                'hostname' => $hostname
+        ));
+    }
+
+    /**
+     * @Route("/sitemap-es.xml", name="sitemap_es")
+     */
+    public function sitemapEsAction(Request $request)
+    {
+        $em = $this->getDoctrine()->getManager();
+        $urls = array();
+        $hostname = $request->getSchemeAndHttpHost();
+        $posts = $em->getRepository('AppBundle:Post')
+                ->findBy(array(
+                        'status' => 'publish'), array(
+                        'modDate' => 'DESC'
+                ));
+        foreach ($posts as $post) {
+            $urls[] = array(
+                    'loc' => $this->get('router')->generate('post', array(
+                            'slug' => $post->getSlug(),
+                            '_locale' => 'es'
+                    )),
+                    'modDate' => $post->getModDate(),
+                    'changefreq' => 'daily',
+                    'priority' => '0.5'
+            );
+        }
+        $urls[] = array(
+                'loc' => $this->get('router')->generate('home'),
+                'changefreq' => 'weekly',
+                'priority' => '1.0'
+        );
+        return $this->render('public/sitemap.xml.twig', array(
+                'urls' => $urls,
+                'hostname' => $hostname
+        ));
+    }
+}


### PR DESCRIPTION
The point of this PR is simply SEO. As mentioned in #16: we need a sitemap generator. I searched for already created bundles and I didn't find what I was looking for, so…

Well, this new Controller generates an index `/sitemap.xml`, in that index are listed two more sitemaps (one for each one of the supported languages) `/sitemap-en.xml` and `/sitemap-es.xml`. Logically only the posts and pages that have been published (not drafts) are published in sitemaps. In addition, the posts and pages are sorted descendingly **by modification date**.