### PR TITLE
Fixing a bug when a user logs in with user role

### DIFF
--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -44,8 +44,6 @@
             </label>
           </div>
           <div class="form-group">
-            <input type="hidden" name="_target_path"
-                   value="{{ path('admin') }}"/>
             <button type="submit" id="submit" name="submit"
                     class="btn btn-primary">
               <i class="fa fa-sign-in" aria-hidden="true"></i>

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -24,6 +24,8 @@ security:
             form_login:
                 login_path: login
                 check_path: login
+                success_handler: security.authentication.customized_success_handler
+                default_target_path: home
             logout:
                 path: logout
                 target: /

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -43,3 +43,9 @@ services:
 
     AppBundle\Twig\AppExtension:
         $locales: '%app.locales%'
+
+    security.authentication.customized_success_handler:
+        class: AppBundle\Services\LoginSuccessHandler
+        arguments: ["@router", "@security.authorization_checker"]
+        tags:
+            - { name: 'monolog.logger', channel: 'security' }

--- a/src/AppBundle/Services/LoginSuccessHandler.php
+++ b/src/AppBundle/Services/LoginSuccessHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AppBundle\Services;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+class LoginSuccessHandler implements AuthenticationSuccessHandlerInterface
+{
+    protected $router;
+    protected $authorizationChecker;
+
+    public function __construct(RouterInterface $router,
+                                AuthorizationCheckerInterface $authorizationChecker)
+    {
+        $this->router = $router;
+        $this->authorizationChecker = $authorizationChecker;
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token)
+    {
+        if ($this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN')) {
+            $response = new RedirectResponse($this->router->generate('admin'));
+        } elseif ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+            $response = new RedirectResponse($this->router->generate('admin'));
+        } elseif ($this->authorizationChecker->isGranted('ROLE_USER')) {
+            $response = new RedirectResponse($this->router->generate('home'));
+        }
+        return $response;
+    }
+}


### PR DESCRIPTION
As I mentioned in issue #26: after the successful login of a user with a user role was redirected to the admin panel, a user with a user role doesn't have access to the admin panel, so there was a 403 error. Now this was fixed. Depending on the role of the user will be redirected to his correct page (for now: admins and superadmins to the admin panel and users to the homepage).