### PR TITLE
Improving my test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before-install:
 install:
     - composer install
     - cp app/config/parameters.yml.dist app/config/parameters.yml
-    - ./bin/console doctrine:database:create
-    - ./bin/console doctrine:schema:create
-    - ./bin/console doctrine:fixtures:load --append
+    - ./bin/console doctrine:database:create --env=test
+    - ./bin/console doctrine:schema:create --env=test
+    - ./bin/console doctrine:fixtures:load -n --env=test
 
 script:
     - ./vendor/bin/simple-phpunit -v

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This application is being developed from scratch using the [Symfony](https://sym
 * [Parsedown](https://github.com/erusev/parsedown)
 * [highlight.js](https://github.com/isagalaev/highlight.js)
 * [OrnicarGravatarBundle](https://github.com/henrikbjorn/GravatarBundle)
+* [DAMADoctrineTestBundle](https://github.com/dmaicher/doctrine-test-bundle)
 
 # Contributing
 Read the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information about to

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -25,6 +25,10 @@ class AppKernel extends Kernel
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
 
+            if ('test' === $this->getEnvironment()) {
+                $bundles[] = new DAMA\DoctrineTestBundle\DAMADoctrineTestBundle();
+            }
+
             if ('dev' === $this->getEnvironment()) {
                 $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
                 $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -24,5 +24,5 @@ doctrine:
     dbal:
         driver: pdo_sqlite
         memory: true
-        path: %kernel.project_dir%/test.sqlite
+        path: "%kernel.project_dir%/test.sqlite"
         charset: UTF8

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -19,3 +19,10 @@ security:
     firewalls:
         main:
             http_basic: ~
+
+doctrine:
+    dbal:
+        driver: pdo_sqlite
+        memory: true
+        path: %kernel.project_dir%/var/data/test.sqlite
+        charset: UTF8

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -24,5 +24,5 @@ doctrine:
     dbal:
         driver: pdo_sqlite
         memory: true
-        path: %kernel.project_dir%/var/data/test.sqlite
+        path: %kernel.project_dir%/test.sqlite
         charset: UTF8

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "twig/twig": "^1.0||^2.0"
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^3.2",
         "doctrine/doctrine-fixtures-bundle": "^2.3",
         "sensio/generator-bundle": "^3.0",
         "symfony/phpunit-bridge": "^3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdf3c0b6da023b913743265ae45f4a44",
+    "content-hash": "cec892fd97997b5ee734fbf8b628bf50",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -2419,6 +2419,62 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "0a96aed300fa4390291dbb9999daf836e2bd0a33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/0a96aed300fa4390291dbb9999daf836e2bd0a33",
+                "reference": "0a96aed300fa4390291dbb9999daf836e2bd0a33",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "~2.5",
+                "doctrine/doctrine-bundle": "~1.4",
+                "php": ">=5.5.0",
+                "symfony/framework-bundle": "~2.7|~3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src/DAMA/DoctrineTestBundle"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony 2/3 bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "Symfony 3",
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "symfony 2",
+                "tests"
+            ],
+            "time": "2017-08-15T11:57:21+00:00"
+        },
         {
             "name": "doctrine/data-fixtures",
             "version": "v1.2.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,4 +28,9 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="\DAMA\DoctrineTestBundle\PHPUnit\LegacyPHPUnitListener" />
+    </listeners>
+
 </phpunit>

--- a/tests/AppBundle/Controller/AdminControllerTest.php
+++ b/tests/AppBundle/Controller/AdminControllerTest.php
@@ -38,6 +38,8 @@ class AdminControllerTest extends WebTestCase
             'PHP_AUTH_PW' => '123456',
         ]);
         $crawler = $client->request('GET', '/es/admin/posts/add');
+        $this->assertSame(Response::HTTP_OK,
+            $client->getResponse()->getStatusCode());
         $form = $crawler->selectButton('submit')->form(array(
             'appbundle_post[titleEs]' => $postTitleEs,
             'appbundle_post[contentEs]' => $postContentEs,
@@ -66,6 +68,8 @@ class AdminControllerTest extends WebTestCase
             'PHP_AUTH_PW' => '123456',
         ]);
         $crawler = $client->request('GET', '/es/admin/posts/edit/1');
+        $this->assertSame(Response::HTTP_OK,
+            $client->getResponse()->getStatusCode());
         $form = $crawler->selectButton('submit')->form(array(
             'appbundle_post[titleEn]' => $newBlogPostTitle,
         ));
@@ -82,9 +86,9 @@ class AdminControllerTest extends WebTestCase
             'PHP_AUTH_PW' => '123456',
         ]);
         $client->followRedirects(true);
-        $crawler = $client->request('GET', '/es/admin/posts/del/2');
+        $crawler = $client->request('GET', '/es/admin/posts/del/1');
         $post = $client->getContainer()->get('doctrine')
-            ->getRepository(Post::class)->find(2);
+            ->getRepository(Post::class)->find(1);
         $this->assertNull($post);
     }
 
@@ -101,6 +105,8 @@ class AdminControllerTest extends WebTestCase
         $newUserBio = 'Testing Bio';
         $newUserUrl = 'hhtps://sargantanacode.es/';
         $crawler = $client->request('GET', '/es/admin/users/add');
+        $this->assertSame(Response::HTTP_OK,
+            $client->getResponse()->getStatusCode());
         $form = $crawler->selectButton('submit')->form(array(
             'appbundle_user[plainPassword][first]' => $newUserPassword,
             'appbundle_user[plainPassword][second]' => $newUserPassword,
@@ -127,13 +133,15 @@ class AdminControllerTest extends WebTestCase
             'PHP_AUTH_USER' => 'alice',
             'PHP_AUTH_PW' => '123456',
         ]);
-        $crawler = $client->request('GET', '/es/admin/users/edit/4');
+        $crawler = $client->request('GET', '/es/admin/users/edit/2');
+        $this->assertSame(Response::HTTP_OK,
+            $client->getResponse()->getStatusCode());
         $form = $crawler->selectButton('submit')->form(array(
             'appbundle_user[username]' => $newUsername,
         ));
         $client->submit($form);
         $post = $client->getContainer()->get('doctrine')
-            ->getRepository(User::class)->find(4);
+            ->getRepository(User::class)->find(2);
         $this->assertSame($newUsername, $post->getUsername());
     }
 
@@ -144,9 +152,9 @@ class AdminControllerTest extends WebTestCase
             'PHP_AUTH_PW' => '123456',
         ]);
         $client->followRedirects(true);
-        $crawler = $client->request('GET', '/es/admin/users/del/4');
+        $crawler = $client->request('GET', '/es/admin/users/del/2');
         $user = $client->getContainer()->get('doctrine')
-            ->getRepository(User::class)->find(4);
+            ->getRepository(User::class)->find(2);
         $this->assertNull($user);
     }
 }


### PR DESCRIPTION
Yesterday I created the test suite at #30, however, I've seen that it can be improved; this PR is proof of this.

Changes from previous PR:
* Now a specific SQLite DB is used to separate the testing DB from the production DB.
* I've added DAMADoctrineTestBundle to roll back all changes to the test DB every time a new test is run; so every time you run the test suite they all have the same initial DB configuration. This is a great time saver if you consider that we don't need to reset the DB every time.
* Minor changes in admin zone tests.