### PR TITLE
Feature: image uploader for categories and posts

### DIFF
--- a/app/Resources/views/admin/categories/categories-add.html.twig
+++ b/app/Resources/views/admin/categories/categories-add.html.twig
@@ -17,7 +17,7 @@
       <h2 class="text-center mb-4">
         {{ 'CATEGORIES_ADD_TITLE'|trans }}
       </h2>
-      <form name="appbundle_post" method="post">
+      {{ form_start(form,{ 'enctype': "multipart/form-data" }) }}
         <div class="container content">
           <div class="form-group">
             {{ form_label(form.name, 'CATEGORY_NAME') }}
@@ -51,7 +51,8 @@
             <i class="fa fa-eraser" aria-hidden="true"></i>
             &nbsp; {{ 'RESET_BTN'|trans }}</button>
         </div>
-      </form>
+      {% do form.slug.setRendered %}
+      {{ form_end(form) }}
     </div>
   </div>
 {% endblock %}

--- a/app/Resources/views/admin/categories/categories-edit.html.twig
+++ b/app/Resources/views/admin/categories/categories-edit.html.twig
@@ -17,7 +17,7 @@
       <h2 class="text-center mb-4">
         {{ 'CATEGORIES_EDIT_TITLE'|trans }}
       </h2>
-      <form name="appbundle_post" method="post">
+      {{ form_start(form,{ 'enctype': "multipart/form-data" }) }}
         <div class="container content">
           <div class="form-group">
             {{ form_label(form.name, 'CATEGORY_NAME') }}
@@ -56,7 +56,7 @@
             <i class="fa fa-eraser" aria-hidden="true"></i>
             &nbsp; {{ 'RESET_BTN'|trans }}</button>
         </div>
-      </form>
+        {{ form_end(form) }}
     </div>
   </div>
 {% endblock %}

--- a/app/Resources/views/admin/categories/categories.html.twig
+++ b/app/Resources/views/admin/categories/categories.html.twig
@@ -38,7 +38,9 @@
         {% for category in categories %}
           <tr>
             <td class="d-none d-lg-table-cell text-center">
-              <img src="{{ asset('images/test-category.jpg') }}" alt="">
+              {% if category.image is not null %}
+                <img src="{{ asset( 'uploads/' ~ category.image ) }}" alt="{{ category.name }}"/>
+              {% endif %}
             </td>
             <td class="d-none d-sm-table-cell text-center">
               {{ category.name }}

--- a/app/Resources/views/admin/pages/pages-view.html.twig
+++ b/app/Resources/views/admin/pages/pages-view.html.twig
@@ -54,18 +54,6 @@
         </div>
       {% endif %}
     </div>
-    {% if author.bio %}
-      <div class="content mt-4 author">
-        <div class="author__avatar">
-          <img src="{{ gravatar( author.email ) }}"
-               alt="{{ author.name }}"/>
-        </div>
-        <div class="author__bio">
-          <h2>{{ author.name }}</h2>
-          {{ author.bio|raw|md2html }}
-        </div>
-      </div>
-    {% endif %}
     <div class="buttons mt-4">
       <a href="{{ path('admin_pages') }}" class="btn btn-primary">
         <i class="fa fa-arrow-left" aria-hidden="true"></i>

--- a/app/Resources/views/admin/posts/posts-add.html.twig
+++ b/app/Resources/views/admin/posts/posts-add.html.twig
@@ -17,7 +17,7 @@
       <h2 class="text-center mb-4">
         {{ 'POSTS_ADD_TITLE'|trans }}
       </h2>
-      <form name="appbundle_post" method="post">
+      {{ form_start(form,{ 'enctype': "multipart/form-data" }) }}
         <div class="container content">
           <div class="form-group">
             {{ form_label(form.titleEs, 'POST_TITLE_ES') }}
@@ -89,7 +89,10 @@
             <i class="fa fa-eraser" aria-hidden="true"></i>
             &nbsp; {{ 'RESET_BTN'|trans }}</button>
         </div>
-      </form>
+      {% do form.author.setRendered %}
+      {% do form.slug.setRendered %}
+      {% do form.navbar.setRendered %}
+      {{ form_end(form) }}
     </div>
   </div>
 {% endblock %}

--- a/app/Resources/views/admin/posts/posts-edit.html.twig
+++ b/app/Resources/views/admin/posts/posts-edit.html.twig
@@ -17,90 +17,95 @@
       <h2 class="text-center mb-4">
         {{ 'POSTS_EDIT_TITLE'|trans }}
       </h2>
-      <form name="appbundle_post" method="post">
-        <div class="container content">
-          <div class="form-group">
-            {{ form_label(form.titleEs, 'POST_TITLE_ES') }}
-            {{ form_widget(form.titleEs, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.contentEs, 'POST_CONTENT_ES') }}
-            {{ form_widget(form.contentEs, { 'attr': {
-              'class': 'form-control',
-              'rows': 10} }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.excerptEs, 'POST_EXCERPT_ES') }}
-            {{ form_widget(form.excerptEs, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
+      {{ form_start(form,{ 'enctype': "multipart/form-data" }) }}
+      <div class="container content">
+        {% if post.image is not null %}
+          <img src="{{ asset( 'uploads/' ~ post.image ) }}" alt=""
+               class="post-header">
+        {% endif %}
+        <div class="form-group">
+          {{ form_label(form.titleEs, 'POST_TITLE_ES') }}
+          {{ form_widget(form.titleEs, { 'attr':
+            {'class': 'form-control'} }) }}
         </div>
+        <div class="form-group">
+          {{ form_label(form.contentEs, 'POST_CONTENT_ES') }}
+          {{ form_widget(form.contentEs, { 'attr': {
+            'class': 'form-control',
+            'rows': 10} }) }}
+        </div>
+        <div class="form-group">
+          {{ form_label(form.excerptEs, 'POST_EXCERPT_ES') }}
+          {{ form_widget(form.excerptEs, { 'attr':
+            {'class': 'form-control'} }) }}
+        </div>
+      </div>
 
-        <div class="container content mt-5">
-          <div class="form-group">
-            {{ form_label(form.titleEn, 'POST_TITLE_EN') }}
-            {{ form_widget(form.titleEn, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.contentEn, 'POST_CONTENT_EN') }}
-            {{ form_widget(form.contentEn, { 'attr': {
-              'class': 'form-control',
-              'rows': 10} }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.excerptEn, 'POST_EXCERPT_EN') }}
-            {{ form_widget(form.excerptEn, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
+      <div class="container content mt-5">
+        <div class="form-group">
+          {{ form_label(form.titleEn, 'POST_TITLE_EN') }}
+          {{ form_widget(form.titleEn, { 'attr':
+            {'class': 'form-control'} }) }}
         </div>
+        <div class="form-group">
+          {{ form_label(form.contentEn, 'POST_CONTENT_EN') }}
+          {{ form_widget(form.contentEn, { 'attr': {
+            'class': 'form-control',
+            'rows': 10} }) }}
+        </div>
+        <div class="form-group">
+          {{ form_label(form.excerptEn, 'POST_EXCERPT_EN') }}
+          {{ form_widget(form.excerptEn, { 'attr':
+            {'class': 'form-control'} }) }}
+        </div>
+      </div>
 
-        <div class="container content mt-5">
-          <div class="form-group">
-            {{ form_label(form.author, 'POST_AUTHOR') }}
-            {{ form_widget(form.author, { 'attr':
-              {'class': 'form-control'},
-              'value': author.id|number_format(0) }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.category, 'POST_CATEGORY') }}
-            {{ form_widget(form.category, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.status, 'POST_STATUS') }}
-            {{ form_widget(form.status, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.slug, 'POST_SLUG') }}
-            {{ form_widget(form.slug, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.commentStatus, 'POST_COMMENT_STATUS') }}
-            {{ form_widget(form.commentStatus, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
-          <div class="form-group">
-            {{ form_label(form.image, 'POST_IMAGE') }}
-            {{ form_widget(form.image, { 'attr':
-              {'class': 'form-control'} }) }}
-          </div>
+      <div class="container content mt-5">
+        <div class="form-group">
+          {{ form_label(form.author, 'POST_AUTHOR') }}
+          {{ form_widget(form.author, { 'attr':
+            {'class': 'form-control'},
+            'value': author.id|number_format(0) }) }}
         </div>
-        {{ form_widget(form._token) }}
-        <div class="container buttons mt-5">
-          <button type="submit" id="submit" name="submit"
-                  class="btn btn-primary">
-            <i class="fa fa-check" aria-hidden="true"></i>
-            &nbsp; {{ 'EDIT_BTN'|trans }}</button>
-          <button type="reset" id="submit" name="submit"
-                  class="btn">
-            <i class="fa fa-eraser" aria-hidden="true"></i>
-            &nbsp; {{ 'RESET_BTN'|trans }}</button>
+        <div class="form-group">
+          {{ form_label(form.category, 'POST_CATEGORY') }}
+          {{ form_widget(form.category, { 'attr':
+            {'class': 'form-control'} }) }}
         </div>
-      </form>
+        <div class="form-group">
+          {{ form_label(form.status, 'POST_STATUS') }}
+          {{ form_widget(form.status, { 'attr':
+            {'class': 'form-control'} }) }}
+        </div>
+        <div class="form-group">
+          {{ form_label(form.slug, 'POST_SLUG') }}
+          {{ form_widget(form.slug, { 'attr':
+            {'class': 'form-control'} }) }}
+        </div>
+        <div class="form-group">
+          {{ form_label(form.commentStatus, 'POST_COMMENT_STATUS') }}
+          {{ form_widget(form.commentStatus, { 'attr':
+            {'class': 'form-control'} }) }}
+        </div>
+        <div class="form-group">
+          {{ form_label(form.image, 'POST_IMAGE') }}
+          {{ form_widget(form.image, { 'attr':
+            {'class': 'form-control'} }) }}
+        </div>
+      </div>
+      {{ form_widget(form._token) }}
+      <div class="container buttons mt-5">
+        <button type="submit" id="submit" name="submit"
+                class="btn btn-primary">
+          <i class="fa fa-check" aria-hidden="true"></i>
+          &nbsp; {{ 'EDIT_BTN'|trans }}</button>
+        <button type="reset" id="submit" name="submit"
+                class="btn">
+          <i class="fa fa-eraser" aria-hidden="true"></i>
+          &nbsp; {{ 'RESET_BTN'|trans }}</button>
+      </div>
+      {% do form.navbar.setRendered %}
+      {{ form_end(form) }}
     </div>
   </div>
 {% endblock %}

--- a/app/Resources/views/admin/posts/posts-view.html.twig
+++ b/app/Resources/views/admin/posts/posts-view.html.twig
@@ -8,19 +8,23 @@
 
 {% block body %}
   <div class="container mt-5 page">
-    <h2>
-      {% if app.request.locale == 'en' and post.titleEn %}
-        {{ post.titleEn }}
-      {% elseif app.request.locale == 'en' and post.titleEs %}
-        {{ post.titleEs }}
+    <div class="content mb-4">
+      {% if post.image is not null %}
+        <img src="{{ asset( 'uploads/' ~ post.image ) }}" alt=""
+             class="post-header">
       {% endif %}
-      {% if app.request.locale == 'es' and post.titleEs %}
-        {{ post.titleEs }}
-      {% elseif app.request.locale == 'es' and post.titleEn %}
-        {{ post.titleEn }}
-      {% endif %}
-    </h2>
-    <div class="content">
+      <h2>
+        {% if app.request.locale == 'en' and post.titleEn %}
+          {{ post.titleEn }}
+        {% elseif app.request.locale == 'en' and post.titleEs %}
+          {{ post.titleEs }}
+        {% endif %}
+        {% if app.request.locale == 'es' and post.titleEs %}
+          {{ post.titleEs }}
+        {% elseif app.request.locale == 'es' and post.titleEn %}
+          {{ post.titleEn }}
+        {% endif %}
+      </h2>
       {% if app.request.locale == 'en' and not post.titleEn or
       app.request.locale == 'es' and not post.titleEs %}
         <div class="alert alert-danger" role="alert">
@@ -54,17 +58,8 @@
         </div>
       {% endif %}
     </div>
-    {% if author.bio %}
-      <div class="content mt-4 author">
-        <div class="author__avatar">
-          <img src="{{ gravatar( author.email ) }}"
-               alt="{{ author.name }}"/>
-        </div>
-        <div class="author__bio">
-          <h2>{{ author.name }}</h2>
-          {{ author.bio|raw|md2html }}
-        </div>
-      </div>
+    {% if user.bio and post.type != 'page' %}
+      {% include('/public/_user-profile.html.twig') %}
     {% endif %}
     <div class="buttons mt-4">
       <a href="{{ path('admin_posts') }}" class="btn btn-primary">

--- a/app/Resources/views/public/_content.html.twig
+++ b/app/Resources/views/public/_content.html.twig
@@ -5,7 +5,10 @@
         <a href="{{ path('post', { 'slug': post.slug }) }}">
           <span class="date-badge">{{ post.date|date("d/m/Y") }}</span>
           <span class="category-badge">{{ post.category.name }}</span>
-          <img src="{{ asset('images/test-image.jpg') }}" alt="">
+          {% if post.image is not null %}
+            <img src="{{ asset( 'uploads/' ~ post.image ) }}"
+                 alt="{{ post.titleEs }}">
+          {% endif %}
           <div class="list__content">
             <h4 class="list__title">
               {% if app.request.locale == 'en' and post.titleEn %}

--- a/app/Resources/views/public/categories.html.twig
+++ b/app/Resources/views/public/categories.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}
-{{ 'CATEGORIES_LIST_TITLE'|trans }} — SargantanaCode
+  {{ 'CATEGORIES_LIST_TITLE'|trans }} — SargantanaCode
 {% endblock %}
 
 {% block body_id "categories" %}
@@ -14,8 +14,11 @@
           <div class="col-12 col-sm-6 col-md-3 mb-4">
             <div class="list">
               <a href="{{ path('category', { 'slug': category.slug }) }}">
-                <img src="{{ asset('images/test-category.jpg') }}" alt=""
-                     class="list__image">
+                {% if category.image is not null %}
+                  <img src="{{ asset( 'uploads/' ~ category.image ) }}"
+                       alt="{{ category.name }}"
+                       class="list__image">
+                {% endif %}
                 <div class="list__content">
                   <h4 class="list__title">{{ category.name }}</h4>
                   <p class="list__text">

--- a/app/Resources/views/public/category.html.twig
+++ b/app/Resources/views/public/category.html.twig
@@ -9,10 +9,12 @@
 {% block body %}
   <div class="container mt-5 page">
     <div class="content category">
-      <div class="category__avatar">
-        <img src="{{ asset('images/test-category.jpg') }}"
-             alt="{{ category.name }}"/>
-      </div>
+      {% if category.image is not null %}
+        <div class="category__avatar">
+          <img src="{{ asset( 'uploads/' ~ category.image ) }}"
+               alt="{{ category.name }}"/>
+        </div>
+      {% endif %}
       <div class="category__desc">
         <h2>{{ category.name }}</h2>
         {% if app.request.locale == 'en' and category.descriptionEn %}

--- a/app/Resources/views/public/index.xml.twig
+++ b/app/Resources/views/public/index.xml.twig
@@ -13,32 +13,35 @@
           <title>{{ post.titleEs }}</title>
           <description>{{ post.excerptEs }}</description>
           <content:encoded>
-            <![CDATA[{{ post.contentEs|raw|md2html }}]]>
+            <![CDATA[<img src="{{ asset( 'uploads/' ~ post.image ) }}" alt="{{ post.titleEs }}" />
+            {{ post.contentEs|raw|md2html }}
+            ]]>
           </content:encoded>
         {% elseif app.request.locale == 'es' and post.titleEn %}
           <title>{{ post.titleEn }}</title>
           <description>{{ post.excerptEn }}</description>
           <content:encoded>
-            <![CDATA[
-                            {{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
-                            {{ post.contentEn|raw|md2html }}
-                        ]]>
+            <![CDATA[{{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
+            <img src="{{ asset( 'uploads/' ~ post.image ) }}" alt="{{ post.titleEs }}" />
+            {{ post.contentEn|raw|md2html }}
+            ]]>
           </content:encoded>
         {% endif %}
         {% if app.request.locale == 'en' and post.titleEn %}
           <title>{{ post.titleEn }}</title>
           <description>{{ post.excerptEn }}</description>
           <content:encoded>
-            <![CDATA[{{ post.contentEn|raw|md2html }}]]>
+            <![CDATA[<img src="{{ asset( 'uploads/' ~ post.image ) }}" alt="{{ post.titleEs }}" />
+            {{ post.contentEn|raw|md2html }}]]>
           </content:encoded>
         {% elseif app.request.locale == 'en' and post.titleEs %}
           <title>{{ post.titleEs }}</title>
           <description>{{ post.excerptEs }}</description>
           <content:encoded>
-            <![CDATA[
-                            {{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
-                            {{ post.contentEs|raw|md2html }}
-                        ]]>
+            <![CDATA[{{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
+            <img src="{{ asset( 'uploads/' ~ post.image ) }}" alt="{{ post.titleEs }}" />
+            {{ post.contentEs|raw|md2html }}
+            ]]>
           </content:encoded>
         {% endif %}
         <link>{{ url('post', {'slug': post.slug}) }}</link>

--- a/app/Resources/views/public/post.html.twig
+++ b/app/Resources/views/public/post.html.twig
@@ -28,8 +28,11 @@
           {{ post.category.name }}
           </a>
         </span>
-        <img src="{{ asset('images/test-image.jpg') }}" alt=""
-             class="post-header">
+        {% if post.image is not null %}
+          <img src="{{ asset( 'uploads/' ~ post.image ) }}"
+               alt="{{ post.titleEs }}"
+               class="post-header">
+        {% endif %}
       {% endif %}
       <h2 class="post-title">
         {% if app.request.locale == 'en' and post.titleEn %}

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ornicar/gravatar-bundle": "^1.1",
         "sensio/distribution-bundle": "^5.0.19",
         "sensio/framework-extra-bundle": "^3.0.2",
+        "symfony/filesystem": "^3.3",
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/polyfill-apcu": "^1.0",
         "symfony/swiftmailer-bundle": "^2.3.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cec892fd97997b5ee734fbf8b628bf50",
+    "content-hash": "6149b060b67a13475cb51b5b746b88f6",
     "packages": [
         {
             "name": "cocur/slugify",

--- a/src/AppBundle/Controller/PublicController.php
+++ b/src/AppBundle/Controller/PublicController.php
@@ -71,7 +71,7 @@ class PublicController extends Controller
             ));
         }
         $categoryRepo = $em->getRepository('AppBundle:Category');
-        $categories = $categoryRepo->findAll();
+        $categories = $categoryRepo->findBy(array(), array('name' => 'ASC'));
         $slug = $request->attributes->get('slug');
         if (!$this->get('security.authorization_checker')
             ->isGranted('ROLE_ADMIN')) {

--- a/src/AppBundle/Entity/Category.php
+++ b/src/AppBundle/Entity/Category.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Category
@@ -53,6 +54,7 @@ class Category
      * @var string
      *
      * @ORM\Column(name="image", type="string", length=255, nullable=true)
+     * @Assert\File(mimeTypes={ "image/jpeg" })
      */
     private $image;
 

--- a/src/AppBundle/Entity/Post.php
+++ b/src/AppBundle/Entity/Post.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Post
@@ -124,6 +125,7 @@ class Post
      * @var string
      *
      * @ORM\Column(name="image", type="string", length=100, nullable=true)
+     * @Assert\File(mimeTypes={ "image/jpeg" })
      */
     private $image;
 
@@ -504,7 +506,7 @@ class Post
      */
     public function setImage($image)
     {
-        $this->format = $image;
+        $this->image = $image;
 
         return $this;
     }

--- a/src/AppBundle/Form/CategoryType.php
+++ b/src/AppBundle/Form/CategoryType.php
@@ -22,7 +22,8 @@ class CategoryType extends AbstractType
             ->add('descriptionEs', TextareaType::class)
             ->add('descriptionEn', TextareaType::class)
             ->add('image', FileType::class, array(
-                'required' => false
+                'required' => false,
+                'data_class' => null
             ));
     }
 

--- a/src/AppBundle/Form/PostType.php
+++ b/src/AppBundle/Form/PostType.php
@@ -46,7 +46,8 @@ class PostType extends AbstractType
                         'required' => false
                 ))
                 ->add('image', FileType::class, array(
-                        'required' => false
+                        'required' => false,
+                        'data_class' => null
                 ))
                 ->add('commentStatus', ChoiceType::class, array(
                         'choices' => array(


### PR DESCRIPTION
Although I had already designed how the images would be, it was still on a provisional basis and images upload from the categories and posts forms wasn't functional. Now images can be uploaded, and in addition, I've implemented a duplicate files control: when we want to upload a new image to a existing category or post it removes the previous file; this file is also removed when we remove a category or a post.