### PR TITLE
Fixing an issue when editing a page

### DIFF
--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -319,6 +319,7 @@ class AdminController extends Controller
             }
             $slug = new Slugify();
             $page->setSlug($slug->slugify($form->get('slug')->getData()));
+            $page->setCommentStatus('close');
             $em->persist($page);
             $flush = $em->flush();
             if (!$flush) {


### PR DESCRIPTION
When editing a page, the comments were not set as closed by default. This should now be fixed.