### PR TITLE
Simplifying everything related to languages

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -1,6 +1,5 @@
 DESC: "SargantanaCode is a website where you can find different subjects related to computer science but mainly related to programming, with Spanish free content"
 ONLY_ADMIN: "You need to be an admin to perform this action"
-LANGUAGE_NOT_AVAILABLE: "English version of this post was not found, showing the Spanish version instead"
 GITHUB_REPO: "This project is open source, you can find it on %link_start%our GitHub repository%link_end%"
 
 # Titles

--- a/app/Resources/views/admin/categories/categories.html.twig
+++ b/app/Resources/views/admin/categories/categories.html.twig
@@ -44,26 +44,16 @@
               {% endif %}
             </td>
             <td class="d-none d-sm-table-cell text-center">
-              {% if app.request.locale == 'es' and category.nameEs %}
+              {% if app.request.locale == 'es' %}
                 {{ category.nameEs }}
-              {% elseif app.request.locale == 'es' and category.nameEn %}
+              {% else %}
                 {{ category.nameEn }}
-              {% endif %}
-              {% if app.request.locale == 'en' and category.nameEn %}
-                {{ category.nameEn }}
-              {% elseif app.request.locale == 'en' and category.nameEs %}
-                {{ category.nameEs }}
               {% endif %}
             </td>
-            {% if app.request.locale == 'es' and category.descriptionEs %}
+            {% if app.request.locale == 'es' %}
               <td>{{ category.descriptionEs }}</td>
-            {% elseif app.request.locale == 'es' and category.descriptionEn %}
+            {% else %}
               <td>{{ category.descriptionEn }}</td>
-            {% endif %}
-            {% if app.request.locale == 'en' and category.descriptionEn %}
-              <td>{{ category.descriptionEn }}</td>
-            {% elseif app.request.locale == 'en' and category.descriptionEs %}
-              <td>{{ category.descriptionEs }}</td>
             {% endif %}
             <td class="text-center">
               <a href="{{ path('category', { 'slug': category.slug }) }}"

--- a/app/Resources/views/admin/comments/_comments-list.html.twig
+++ b/app/Resources/views/admin/comments/_comments-list.html.twig
@@ -38,15 +38,10 @@
     </td>
     <td>
       <a href="{{ path('post', {'slug': comment.slug }) }}">
-        {% if app.request.locale == 'es' and comment.title_es %}
+        {% if app.request.locale == 'es' %}
           {{ comment.title_es }}
-        {% elseif app.request.locale == 'es' and comment.title_en %}
+        {% else %}
           {{ comment.title_en }}
-        {% endif %}
-        {% if app.request.locale == 'en' and comment.title_en %}
-          {{ comment.title_en }}
-        {% elseif app.request.locale == 'en' and comment.title_es %}
-          {{ comment.title_es }}
         {% endif %}
       </a>
       <hr/>

--- a/app/Resources/views/admin/comments/comments-pending.html.twig
+++ b/app/Resources/views/admin/comments/comments-pending.html.twig
@@ -51,15 +51,10 @@
             </td>
             <td>
               <a href="{{ path('post', {'slug': comment.slug }) }}">
-                {% if app.request.locale == 'es' and comment.title_es %}
+                {% if app.request.locale == 'es' %}
                   {{ comment.title_es }}
-                {% elseif app.request.locale == 'es' and comment.title_en %}
+                {% else %}
                   {{ comment.title_en }}
-                {% endif %}
-                {% if app.request.locale == 'en' and comment.title_en %}
-                  {{ comment.title_en }}
-                {% elseif app.request.locale == 'en' and comment.title_es %}
-                  {{ comment.title_es }}
                 {% endif %}
               </a>
               <hr/>

--- a/app/Resources/views/admin/images/images.html.twig
+++ b/app/Resources/views/admin/images/images.html.twig
@@ -39,43 +39,26 @@
           <tr>
             <td class="d-none d-lg-table-cell text-center">
               {% if image.file is not null %}
-                {% if app.request.locale == 'es' and image.titleEs %}
+                {% if app.request.locale == 'es' %}
                   <img src="{{ asset( 'uploads/' ~ image.file ) }}"
                        alt="{{ image.titleEs }}"/>
-                {% elseif app.request.locale == 'es' and image.titleEn %}
+                {% else %}
                   <img src="{{ asset( 'uploads/' ~ image.file ) }}"
                        alt="{{ image.titleEn }}"/>
-                {% endif %}
-                {% if app.request.locale == 'en' and image.titleEn %}
-                  <img src="{{ asset( 'uploads/' ~ image.file ) }}"
-                       alt="{{ image.titleEn }}"/>
-                {% elseif app.request.locale == 'en' and image.titleEs %}
-                  <img src="{{ asset( 'uploads/' ~ image.file ) }}"
-                       alt="{{ image.titleEs }}"/>
                 {% endif %}
               {% endif %}
             </td>
             <td class="d-none d-sm-table-cell text-center">
-              {% if app.request.locale == 'es' and image.titleEs %}
+              {% if app.request.locale == 'es' %}
                 {{ image.titleEs }}
-              {% elseif app.request.locale == 'es' and image.titleEn %}
+              {% else %}
                 {{ image.titleEn }}
-              {% endif %}
-              {% if app.request.locale == 'en' and image.titleEn %}
-                {{ image.titleEn }}
-              {% elseif app.request.locale == 'en' and image.titleEs %}
-                {{ image.titleEs }}
               {% endif %}
             </td>
-            {% if app.request.locale == 'es' and image.descriptionEs %}
+            {% if app.request.locale == 'es' %}
               <td>{{ image.descriptionEs }}</td>
-            {% elseif app.request.locale == 'es' and image.descriptionEn %}
+            {% else %}
               <td>{{ image.descriptionEn }}</td>
-            {% endif %}
-            {% if app.request.locale == 'en' and image.descriptionEn %}
-              <td>{{ image.descriptionEn }}</td>
-            {% elseif app.request.locale == 'en' and image.descriptionEs %}
-              <td>{{ image.descriptionEs }}</td>
             {% endif %}
             <td class="text-center">
               <a href="{{ path('admin_images_edit', {'id': image.id}) }}"

--- a/app/Resources/views/admin/pages/pages-view.html.twig
+++ b/app/Resources/views/admin/pages/pages-view.html.twig
@@ -9,44 +9,20 @@
 {% block body %}
   <div class="container mt-5 page">
     <h2>
-      {% if app.request.locale == 'en' and page.titleEn %}
-        {{ page.titleEn }}
-      {% elseif app.request.locale == 'en' and page.titleEs %}
+      {% if app.request.locale == 'es' %}
         {{ page.titleEs }}
-      {% endif %}
-      {% if app.request.locale == 'es' and page.titleEs %}
-        {{ page.titleEs }}
-      {% elseif app.request.locale == 'es' and page.titleEn %}
+      {% else %}
         {{ page.titleEn }}
       {% endif %}
     </h2>
     <div class="content">
-      {% if app.request.locale == 'en' and not page.titleEn or
-      app.request.locale == 'es' and not page.titleEs %}
-        <div class="alert alert-danger" role="alert">
-          {{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
-        </div>
-      {% endif %}
-      {% if app.request.locale == 'en' and page.titleEn %}
-        {{ page.contentEn|raw|md2html }}
-        <div class="mt-5">
-          <h3>{{ 'PAGE_EXCERPT'|trans }}</h3>
-          {{ page.excerptEn }}
-        </div>
-      {% elseif app.request.locale == 'en' and page.titleEs %}
+      {% if app.request.locale == 'es' %}
         {{ page.contentEs|raw|md2html }}
         <div class="mt-5">
           <h3>{{ 'PAGE_EXCERPT'|trans }}</h3>
           {{ page.excerptEs }}
         </div>
-      {% endif %}
-      {% if app.request.locale == 'es' and page.titleEs %}
-        {{ page.contentEs|raw|md2html }}
-        <div class="mt-5">
-          <h3>{{ 'PAGE_EXCERPT'|trans }}</h3>
-          {{ page.excerptEs }}
-        </div>
-      {% elseif app.request.locale == 'es' and page.titleEn %}
+      {% else %}
         {{ page.contentEn|raw|md2html }}
         <div class="mt-5">
           <h3>{{ 'PAGE_EXCERPT'|trans }}</h3>

--- a/app/Resources/views/admin/pages/pages.html.twig
+++ b/app/Resources/views/admin/pages/pages.html.twig
@@ -37,15 +37,10 @@
         {% endif %}
         {% for page in pages %}
           <tr>
-            {% if app.request.locale == 'es' and page.titleEs %}
+            {% if app.request.locale == 'es' %}
               <td>{{ page.titleEs }}</td>
-            {% elseif app.request.locale == 'es' and page.titleEn %}
+            {% else %}
               <td>{{ page.titleEn }}</td>
-            {% endif %}
-            {% if app.request.locale == 'en' and page.titleEn %}
-              <td>{{ page.titleEn }}</td>
-            {% elseif app.request.locale == 'en' and page.titleEs %}
-              <td>{{ page.titleEs }}</td>
             {% endif %}
             {% if page.status == 'publish' %}
               <td class="d-none d-sm-table-cell text-center">

--- a/app/Resources/views/admin/posts/_post-list.html.twig
+++ b/app/Resources/views/admin/posts/_post-list.html.twig
@@ -23,15 +23,10 @@
   {% endif %}
   {% for post in posts %}
     <tr>
-      {% if app.request.locale == 'es' and post.titleEs %}
+      {% if app.request.locale == 'es' %}
         <td>{{ post.titleEs }}</td>
-      {% elseif app.request.locale == 'es' and post.titleEn %}
+      {% else %}
         <td>{{ post.titleEn }}</td>
-      {% endif %}
-      {% if app.request.locale == 'en' and post.titleEn %}
-        <td>{{ post.titleEn }}</td>
-      {% elseif app.request.locale == 'en' and post.titleEs %}
-        <td>{{ post.titleEs }}</td>
       {% endif %}
       {% if post.status == 'publish' %}
         <td class="d-none d-sm-table-cell text-center">

--- a/app/Resources/views/admin/posts/posts-view.html.twig
+++ b/app/Resources/views/admin/posts/posts-view.html.twig
@@ -14,43 +14,19 @@
              class="post-header">
       {% endif %}
       <h2>
-        {% if app.request.locale == 'en' and post.titleEn %}
-          {{ post.titleEn }}
-        {% elseif app.request.locale == 'en' and post.titleEs %}
+        {% if app.request.locale == 'es' %}
           {{ post.titleEs }}
-        {% endif %}
-        {% if app.request.locale == 'es' and post.titleEs %}
-          {{ post.titleEs }}
-        {% elseif app.request.locale == 'es' and post.titleEn %}
+        {% else %}
           {{ post.titleEn }}
         {% endif %}
       </h2>
-      {% if app.request.locale == 'en' and not post.titleEn or
-      app.request.locale == 'es' and not post.titleEs %}
-        <div class="alert alert-danger" role="alert">
-          {{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
-        </div>
-      {% endif %}
-      {% if app.request.locale == 'en' and post.titleEn %}
-        {{ post.contentEn|raw|md2html }}
-        <div class="mt-5">
-          <h3>{{ 'POST_EXCERPT'|trans }}</h3>
-          {{ post.excerptEn }}
-        </div>
-      {% elseif app.request.locale == 'en' and post.titleEs %}
+      {% if app.request.locale == 'es' %}
         {{ post.contentEs|raw|md2html }}
         <div class="mt-5">
           <h3>{{ 'POST_EXCERPT'|trans }}</h3>
           {{ post.excerptEs }}
         </div>
-      {% endif %}
-      {% if app.request.locale == 'es' and post.titleEs %}
-        {{ post.contentEs|raw|md2html }}
-        <div class="mt-5">
-          <h3>{{ 'POST_EXCERPT'|trans }}</h3>
-          {{ post.excerptEs }}
-        </div>
-      {% elseif app.request.locale == 'es' and post.titleEn %}
+      {% else %}
         {{ post.contentEn|raw|md2html }}
         <div class="mt-5">
           <h3>{{ 'POST_EXCERPT'|trans }}</h3>

--- a/app/Resources/views/public/_content.html.twig
+++ b/app/Resources/views/public/_content.html.twig
@@ -5,43 +5,33 @@
         <a href="{{ path('post', { 'slug': post.slug }) }}">
           <span class="date-badge">{{ post.date|date("d/m/Y") }}</span>
           <span class="category-badge">
-            {% if app.request.locale == 'en' and post.category.nameEn %}
-              {{ post.category.nameEn }}
-            {% elseif app.request.locale == 'en' and post.titleEs %}
+            {% if app.request.locale == 'es' %}
               {{ post.category.nameEs }}
-            {% endif %}
-            {% if app.request.locale == 'es' and post.category.nameEs %}
-              {{ post.category.nameEs }}
-            {% elseif app.request.locale == 'es' and post.category.nameEn %}
+            {% else %}
               {{ post.category.nameEn }}
             {% endif %}
           </span>
           {% if post.image is not null %}
-            <img src="{{ asset( 'uploads/' ~ post.image ) }}"
-                 alt="{{ post.titleEs }}">
+            {% if app.request.locale == 'es' %}
+              <img src="{{ asset( 'uploads/' ~ post.image ) }}"
+                   alt="{{ post.titleEs }}">
+            {% else %}
+              <img src="{{ asset( 'uploads/' ~ post.image ) }}"
+                   alt="{{ post.titleEn }}">
+            {% endif %}
           {% endif %}
           <div class="list__content">
             <h4 class="list__title">
-              {% if app.request.locale == 'en' and post.titleEn %}
-                {{ post.titleEn }}
-              {% elseif app.request.locale == 'en' and post.titleEs %}
+              {% if app.request.locale == 'es' %}
                 {{ post.titleEs }}
-              {% endif %}
-              {% if app.request.locale == 'es' and post.titleEs %}
-                {{ post.titleEs }}
-              {% elseif app.request.locale == 'es' and post.titleEn %}
+              {% else %}
                 {{ post.titleEn }}
               {% endif %}
             </h4>
             <p class="list__text">
-              {% if app.request.locale == 'en' and post.titleEn %}
-                {{ post.excerptEn }}
-              {% elseif app.request.locale == 'en' and post.titleEs %}
+              {% if app.request.locale == 'es' %}
                 {{ post.excerptEs }}
-              {% endif %}
-              {% if app.request.locale == 'es' and post.titleEs %}
-                {{ post.excerptEs }}
-              {% elseif app.request.locale == 'es' and post.titleEn %}
+              {% else %}
                 {{ post.excerptEn }}
               {% endif %}
             </p>

--- a/app/Resources/views/public/categories.html.twig
+++ b/app/Resources/views/public/categories.html.twig
@@ -32,32 +32,28 @@
             <div class="list">
               <a href="{{ path('category', { 'slug': category.slug }) }}">
                 {% if category.image is not null %}
-                  <img src="{{ asset( 'uploads/' ~ category.image ) }}"
-                       alt="{{ category.nameEs }}"
-                       class="list__image">
+                  {% if app.request.locale == 'es' %}
+                    <img src="{{ asset( 'uploads/' ~ category.image ) }}"
+                         alt="{{ category.nameEs }}"
+                         class="list__image">
+                  {% else %}
+                    <img src="{{ asset( 'uploads/' ~ category.image ) }}"
+                         alt="{{ category.nameEn }}"
+                         class="list__image">
+                  {% endif %}
                 {% endif %}
                 <div class="list__content">
                   <h4 class="list__title">
-                    {% if app.request.locale == 'es' and category.nameEs %}
+                    {% if app.request.locale == 'es' %}
                       {{ category.nameEs }}
-                    {% elseif app.request.locale == 'es' and category.nameEn %}
+                    {% else %}
                       {{ category.nameEn }}
-                    {% endif %}
-                    {% if app.request.locale == 'en' and category.nameEn %}
-                      {{ category.nameEn }}
-                    {% elseif app.request.locale == 'en' and category.nameEs %}
-                      {{ category.nameEs }}
                     {% endif %}
                   </h4>
                   <p class="list__text">
-                    {% if app.request.locale == 'en' and category.descriptionEn %}
-                      {{ category.descriptionEn }}
-                    {% elseif app.request.locale == 'en' and category.descriptionEs %}
+                    {% if app.request.locale == 'es' %}
                       {{ category.descriptionEs }}
-                    {% endif %}
-                    {% if app.request.locale == 'es' and category.descriptionEs %}
-                      {{ category.descriptionEs }}
-                    {% elseif app.request.locale == 'es' and category.descriptionEn %}
+                    {% else %}
                       {{ category.descriptionEn }}
                     {% endif %}
                   </p>

--- a/app/Resources/views/public/category.html.twig
+++ b/app/Resources/views/public/category.html.twig
@@ -1,15 +1,10 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}
-  {% if app.request.locale == 'es' and category.nameEs %}
+  {% if app.request.locale == 'es' %}
     {{ category.nameEs }} — {{ 'TITLE'|trans }}
-  {% elseif app.request.locale == 'es' and category.nameEn %}
+  {% else %}
     {{ category.nameEn }} — {{ 'TITLE'|trans }}
-  {% endif %}
-  {% if app.request.locale == 'en' and category.nameEn %}
-    {{ category.nameEn }} — {{ 'TITLE'|trans }}
-  {% elseif app.request.locale == 'en' and category.nameEs %}
-    {{ category.nameEs }} — {{ 'TITLE'|trans }}
   {% endif %}
 {% endblock %}
 
@@ -17,22 +12,23 @@
   <meta name="twitter:card" content="summary"/>
   <meta name="twitter:site" content="@SargantanaCode"/>
   <meta name="twitter:creator" content="@fjpalacios"/>
-  <meta property="og:url" content="{{ url('category', {'slug': category.slug }) }}"/>
-  {% if app.request.locale == 'es' and category.nameEs %}
+  <meta property="og:url"
+        content="{{ url('category', {'slug': category.slug }) }}"/>
+  {% if app.request.locale == 'es' %}
     <meta property="og:title" content="{{ category.nameEs }} — SargantanaCode"/>
-  {% elseif app.request.locale == 'es' and category.nameEn %}
+  {% else %}
     <meta property="og:title" content="{{ category.nameEn }} — SargantanaCode"/>
-  {% endif %}
-  {% if app.request.locale == 'en' and category.nameEn %}
-    <meta property="og:title" content="{{ category.nameEn }} — SargantanaCode"/>
-  {% elseif app.request.locale == 'en' and category.nameEs %}
-    <meta property="og:title" content="{{ category.nameEs }} — SargantanaCode"/>
   {% endif %}
 
   <meta property="og:site_name" content="SargantanaCode"/>
-  <meta property="article:author" content="https://www.facebook.com/sargantanacode/" />
+  <meta property="article:author"
+        content="https://www.facebook.com/sargantanacode/"/>
   <meta property="fb:admins" content="826302220"/>
-  <meta property="og:description" content="{{ category.descriptionEs }}"/>
+  {% if app.request.locale == 'es' %}
+    <meta property="og:description" content="{{ category.descriptionEs }}"/>
+  {% else %}
+    <meta property="og:description" content="{{ category.descriptionEn }}"/>
+  {% endif %}
   <meta property="og:type" content="article"/>
   {% if category.image is not null %}
     <meta property="og:image"
@@ -50,31 +46,26 @@
     <div class="content category">
       {% if category.image is not null %}
         <div class="category__avatar">
-          <img src="{{ asset( 'uploads/' ~ category.image ) }}"
-               alt="{{ category.nameEs }}"/>
+          {% if app.request.locale == 'es' %}
+            <img src="{{ asset( 'uploads/' ~ category.image ) }}"
+                 alt="{{ category.nameEs }}">
+          {% else %}
+            <img src="{{ asset( 'uploads/' ~ category.image ) }}"
+                 alt="{{ category.nameEn }}">
+          {% endif %}
         </div>
       {% endif %}
       <div class="category__desc">
         <h2>
-          {% if app.request.locale == 'es' and category.nameEs %}
+          {% if app.request.locale == 'es' %}
             {{ category.nameEs }}
-          {% elseif app.request.locale == 'es' and category.nameEn %}
+          {% else %}
             {{ category.nameEn }}
-          {% endif %}
-          {% if app.request.locale == 'en' and category.nameEn %}
-            {{ category.nameEn }}
-          {% elseif app.request.locale == 'en' and category.nameEs %}
-            {{ category.nameEs }}
           {% endif %}
         </h2>
-        {% if app.request.locale == 'en' and category.descriptionEn %}
-          {{ category.descriptionEn }}
-        {% elseif app.request.locale == 'en' and category.descriptionEs %}
+        {% if app.request.locale == 'es' %}
           {{ category.descriptionEs }}
-        {% endif %}
-        {% if app.request.locale == 'es' and category.descriptionEs %}
-          {{ category.descriptionEs }}
-        {% elseif app.request.locale == 'es' and category.descriptionEn %}
+        {% else %}
           {{ category.descriptionEn }}
         {% endif %}
       </div>

--- a/app/Resources/views/public/index.xml.twig
+++ b/app/Resources/views/public/index.xml.twig
@@ -13,7 +13,7 @@
     <language>{{ app.request.locale }}</language>
     {% for post in posts %}
       <item>
-        {% if app.request.locale == 'es' and post.titleEs %}
+        {% if app.request.locale == 'es' %}
           <title>{{ post.titleEs }}</title>
           <description>{{ post.excerptEs }}</description>
           <content:encoded>
@@ -21,7 +21,8 @@
             {{ post.contentEs|raw|md2html }}
             ]]>
           </content:encoded>
-        {% elseif app.request.locale == 'es' and post.titleEn %}
+          <category>{{ post.category.nameEs }}</category>
+        {% else %}
           <title>{{ post.titleEn }}</title>
           <description>{{ post.excerptEn }}</description>
           <content:encoded>
@@ -30,33 +31,12 @@
             {{ post.contentEn|raw|md2html }}
             ]]>
           </content:encoded>
-        {% endif %}
-        {% if app.request.locale == 'en' and post.titleEn %}
-          <title>{{ post.titleEn }}</title>
-          <description>{{ post.excerptEn }}</description>
-          <content:encoded>
-            <![CDATA[<img src="{{ app.request.getSchemeAndHttpHost() ~ asset( '/uploads/' ~ post.image ) }}" alt="{{ post.titleEs }}" />
-            {{ post.contentEn|raw|md2html }}]]>
-          </content:encoded>
-        {% elseif app.request.locale == 'en' and post.titleEs %}
-          <title>{{ post.titleEs }}</title>
-          <description>{{ post.excerptEs }}</description>
-          <content:encoded>
-            <![CDATA[{{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
-            <img src="{{ app.request.getSchemeAndHttpHost() ~ asset( '/uploads/' ~ post.image ) }}" alt="{{ post.titleEs }}" />
-            {{ post.contentEs|raw|md2html }}
-            ]]>
-          </content:encoded>
+          <category>{{ post.category.nameEn }}</category>
         {% endif %}
         <link>{{ url('post', {'slug': post.slug}) }}</link>
         <guid>{{ url('post', {'slug': post.slug}) }}</guid>
         <pubDate>{{ post.date|date(format='r', timezone='GMT') }}</pubDate>
         <dc:creator><![CDATA[{{ post.author.name }}]]></dc:creator>
-        {% if app.request.locale == 'es' %}
-          <category>{{ post.category.nameEs }}</category>
-        {% else %}
-          <category>{{ post.category.nameEn }}</category>
-        {% endif %}
       </item>
     {% endfor %}
   </channel>

--- a/app/Resources/views/public/post.html.twig
+++ b/app/Resources/views/public/post.html.twig
@@ -51,57 +51,43 @@
         <span class="category-badge">
           <a href="{{ path('category', { 'slug': post.category.slug }) }}"
              class="badge-link">
-            {% if app.request.locale == 'en' and post.category.nameEn %}
-              {{ post.category.nameEn }}
-            {% elseif app.request.locale == 'en' and post.titleEs %}
+            {% if app.request.locale == 'es' %}
               {{ post.category.nameEs }}
-            {% endif %}
-            {% if app.request.locale == 'es' and post.category.nameEs %}
-              {{ post.category.nameEs }}
-            {% elseif app.request.locale == 'es' and post.category.nameEn %}
+            {% else %}
               {{ post.category.nameEn }}
             {% endif %}
           </a>
         </span>
         {% if post.image is not null %}
-          <img src="{{ asset( 'uploads/' ~ post.image ) }}"
-               alt="{{ post.titleEs }}"
-               class="post-header">
+          {% if app.request.locale == 'es' %}
+            <img src="{{ asset( 'uploads/' ~ post.image ) }}"
+                 alt="{{ post.titleEs }}"
+                 class="post-header">
+          {% else %}
+            <img src="{{ asset( 'uploads/' ~ post.image ) }}"
+                 alt="{{ post.titleEn }}"
+                 class="post-header">
+          {% endif %}
         {% endif %}
       {% endif %}
       <h2 class="post-title">
-        {% if app.request.locale == 'en' and post.titleEn %}
-          {{ post.titleEn }}
-        {% elseif app.request.locale == 'en' and post.titleEs %}
+        {% if app.request.locale == 'es' %}
           {{ post.titleEs }}
-        {% endif %}
-        {% if app.request.locale == 'es' and post.titleEs %}
-          {{ post.titleEs }}
-        {% elseif app.request.locale == 'es' and post.titleEn %}
+        {% else %}
           {{ post.titleEn }}
         {% endif %}
       </h2>
       <div class="post-body">
-        {% if app.request.locale == 'en' and not post.titleEn or
-        app.request.locale == 'es' and not post.titleEs %}
-          <div class="alert alert-danger" role="alert">
-            {{ 'LANGUAGE_NOT_AVAILABLE'|trans }}
-          </div>
-        {% endif %}
-        {% if app.request.locale == 'en' and post.titleEn %}
-          {{ post.contentEn|raw|md2html }}
-        {% elseif app.request.locale == 'en' and post.titleEs %}
+        {% if app.request.locale == 'es' %}
           {{ post.contentEs|raw|md2html }}
-        {% endif %}
-        {% if app.request.locale == 'es' and post.titleEs %}
-          {{ post.contentEs|raw|md2html }}
-        {% elseif app.request.locale == 'es' and post.titleEn %}
+        {% else %}
           {{ post.contentEn|raw|md2html }}
         {% endif %}
       </div>
     </div>
     {% if post.type == 'post' %}
       <div class="social mb-3">
+        {% if app.request.locale == 'es' %}
         <ul class="social__list">
           <li>
             <a
@@ -119,11 +105,39 @@
             </a>
           </li>
           <li>
-            <a href="mailto:?subject={{ post.titleEs }}&body={{ post.titleEs }} en SargantanaCode: {{ url('post', {'slug': post.slug }) }}" class="social-btn">
+            <a
+              href="mailto:?subject={{ post.titleEs }}&body={{ post.titleEs }} en SargantanaCode: {{ url('post', {'slug': post.slug }) }}"
+              class="social-btn">
               <i class="fa fa-envelope-square" aria-hidden="true"></i>
             </a>
           </li>
         </ul>
+        {% else %}
+          <ul class="social__list">
+            <li>
+              <a
+                href="https://twitter.com/intent/tweet?url={{ url('post', {'slug': post.slug }) }}&text={{ post.titleEn }}&via=SargantanaCode"
+                target="_blank" class="social-btn social-btn--twitter"
+                onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600')return false">
+                <i class="fa fa-twitter-square" aria-hidden="true"></i>
+              </a>
+            </li>
+            <li>
+              <a href="javascript: void(0);"
+                 onclick="javascript:window.open('https://www.facebook.com/sharer.php?u={{ url('post', {'slug': post.slug }) }}&t={{ post.titleEn }}','ventanacompartir', 'toolbar=0, status=0, width=650, height=450')"
+                 target="_blank" class="social-btn social-btn--facebook">
+                <i class="fa fa-facebook-square" aria-hidden="true"></i>
+              </a>
+            </li>
+            <li>
+              <a
+                href="mailto:?subject={{ post.titleEn }}&body={{ post.titleEn }} en SargantanaCode: {{ url('post', {'slug': post.slug }) }}"
+                class="social-btn">
+                <i class="fa fa-envelope-square" aria-hidden="true"></i>
+              </a>
+            </li>
+          </ul>
+        {% endif %}
       </div>
     {% endif %}
     {% if user.bio is defined and post.type != 'page' %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -6,9 +6,9 @@ imports:
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
-    locale: es
-    app.locales: es|en
-    locale_supported: ['es','en']
+    locale: en
+    app.locales: en|es
+    locale_supported: ['en','es']
 
 framework:
     #esi: ~

--- a/src/AppBundle/EventListener/LocaleRewriteListener.php
+++ b/src/AppBundle/EventListener/LocaleRewriteListener.php
@@ -37,7 +37,7 @@ class LocaleRewriteListener implements EventSubscriberInterface
      */
     private $localeRouteParam;
 
-    public function __construct(RouterInterface $router, $defaultLocale = 'es', array $supportedLocales = array('es', 'en'), $localeRouteParam = '_locale')
+    public function __construct(RouterInterface $router, $defaultLocale = 'en', array $supportedLocales = array('en', 'es'), $localeRouteParam = '_locale')
     {
         $this->router = $router;
         $this->routeCollection = $router->getRouteCollection();


### PR DESCRIPTION
When I started designing this page and thought that it was completely available both in Spanish and English I thought that I would find difficult to translate each article into English, it's not so… To lighten the code I've removed all the checks related to languages, assuming that it will always be both in Spanish and English.

In addition, now only shows the page in Spanish to those who have the browser in Spanish, otherwise the page will load in English, which is now the default language to ensure compatibility.