### PR TITLE
Fixing the grid from the categories list for a better viewing

### DIFF
--- a/app/Resources/views/public/categories.html.twig
+++ b/app/Resources/views/public/categories.html.twig
@@ -28,7 +28,7 @@
     <div class="row">
       {% for category in categories %}
         {% if has_posts(category.id) %}
-          <div class="col-12 col-sm-6 col-md-3 mb-4">
+          <div class="col-12 col-sm-6 col-md-4 col-xl-3 mb-4">
             <div class="list">
               <a href="{{ path('category', { 'slug': category.slug }) }}">
                 {% if category.image is not null %}


### PR DESCRIPTION
When a category contains a too long word (such as "SarganataCode") it was displayed incorrectly on small screens. This fix should solve it.